### PR TITLE
Stage 2 zero grad fix

### DIFF
--- a/fastDP/privacy_engine_dist_stage23.py
+++ b/fastDP/privacy_engine_dist_stage23.py
@@ -304,10 +304,13 @@ class PrivacyEngine_Distributed_Stage_2_and_3(object):
         # deepspeed stage 2 modification-----------
         from deepspeed.runtime.zero.stage_1_and_2 import DeepSpeedZeroOptimizer
 
-        def zero_grad_DP_stage2(self, set_grads_to_None=True):
+        def zero_grad_DP_stage2(self, set_grads_to_None=True, set_to_none=None):
             """
             Zero FP16 parameter grads.
             """
+            if set_to_none is not None:
+                # In transformers 4.29, set_grads_to_None is renamed to set_to_none
+                set_grads_to_None = set_to_none
             #print(self.micro_step_id)
 
             # FP32 grad should never exist.


### PR DESCRIPTION
*Issue:* The zero grad function of stage 2 misses the set_to_none argument. Without this argument, training breaks.

*Description of changes:* Added the argument similar to stage 3. Either argument can be used to set gradients to None.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
